### PR TITLE
Add cloud-init section for automated VPS setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,24 +204,6 @@ gh repo set-default owner/repo-name
 
 ---
 
-## References
-
-[^1]: [How To Secure A Linux Server](https://github.com/imthenachoman/How-To-Secure-A-Linux-Server) - Comprehensive guide covering SSH hardening, firewall configuration, intrusion detection, and system monitoring
-
-[^2]: [Termius](https://termius.com/) - Cross-platform SSH client with mosh support, custom keyboards, and seamless authentication across iOS, Android, Windows, macOS, and Linux
-
-[^3]: [Blink Shell](https://blink.sh/) - Professional iOS terminal with mosh integration, VS Code/Codespaces support, external keyboard compatibility, and persistent mobile connections
-
-[^4]: [Mosh](https://mosh.org/) - Mobile shell with automatic network roaming, instant local echo, and connection resilience during network changes and device sleep cycles
-
-[^5]: [How to Add SSH Keys to Droplets](https://docs.digitalocean.com/products/droplets/how-to/add-ssh-keys/) - Official DigitalOcean documentation for adding SSH keys to new or existing droplets
-
-[^6]: [SSH Key Best Practices for 2025](https://www.brandonchecketts.com/archives/ssh-ed25519-key-best-practices-for-2025) - Current best practices for Ed25519 SSH keys, including generation, security, and management recommendations
-
-[^7]: [GitHub CLI Authentication](https://cli.github.com/manual/gh_auth_login) - Official GitHub CLI documentation for authentication setup and token management
-
-[^8]: [Persistent SSH Sessions with tmux](https://dev.to/idoko/persistent-ssh-sessions-with-tmux-25dm) - Guide to using tmux for maintaining persistent terminal sessions across network disconnections
-
 ## Cloud-Init for Automated Setup
 
 For a more automated server setup, use cloud-init to configure your VPS during initial provisioning. This eliminates manual setup steps and ensures consistent configuration.
@@ -320,3 +302,21 @@ Before using, update the cloud-config.yaml:
 4. Adjust firewall rules for your specific requirements
 
 The server will be fully configured and ready for development work within minutes of creation.
+
+## References
+
+[^1]: [How To Secure A Linux Server](https://github.com/imthenachoman/How-To-Secure-A-Linux-Server) - Comprehensive guide covering SSH hardening, firewall configuration, intrusion detection, and system monitoring
+
+[^2]: [Termius](https://termius.com/) - Cross-platform SSH client with mosh support, custom keyboards, and seamless authentication across iOS, Android, Windows, macOS, and Linux
+
+[^3]: [Blink Shell](https://blink.sh/) - Professional iOS terminal with mosh integration, VS Code/Codespaces support, external keyboard compatibility, and persistent mobile connections
+
+[^4]: [Mosh](https://mosh.org/) - Mobile shell with automatic network roaming, instant local echo, and connection resilience during network changes and device sleep cycles
+
+[^5]: [How to Add SSH Keys to Droplets](https://docs.digitalocean.com/products/droplets/how-to/add-ssh-keys/) - Official DigitalOcean documentation for adding SSH keys to new or existing droplets
+
+[^6]: [SSH Key Best Practices for 2025](https://www.brandonchecketts.com/archives/ssh-ed25519-key-best-practices-for-2025) - Current best practices for Ed25519 SSH keys, including generation, security, and management recommendations
+
+[^7]: [GitHub CLI Authentication](https://cli.github.com/manual/gh_auth_login) - Official GitHub CLI documentation for authentication setup and token management
+
+[^8]: [Persistent SSH Sessions with tmux](https://dev.to/idoko/persistent-ssh-sessions-with-tmux-25dm) - Guide to using tmux for maintaining persistent terminal sessions across network disconnections

--- a/README.md
+++ b/README.md
@@ -221,3 +221,102 @@ gh repo set-default owner/repo-name
 [^7]: [GitHub CLI Authentication](https://cli.github.com/manual/gh_auth_login) - Official GitHub CLI documentation for authentication setup and token management
 
 [^8]: [Persistent SSH Sessions with tmux](https://dev.to/idoko/persistent-ssh-sessions-with-tmux-25dm) - Guide to using tmux for maintaining persistent terminal sessions across network disconnections
+
+## Cloud-Init for Automated Setup
+
+For a more automated server setup, use cloud-init to configure your VPS during initial provisioning. This eliminates manual setup steps and ensures consistent configuration.
+
+### Cloud-Init Configuration
+
+Create a `cloud-config.yaml` file:
+
+```yaml
+#cloud-config
+package_update: true
+package_upgrade: true
+
+packages:
+  - mosh
+  - tmux
+  - curl
+  - git
+  - build-essential
+
+users:
+  - name: developer
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [sudo]
+    shell: /bin/bash
+    ssh_authorized_keys:
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGExampleKeyDataHere your-email@example.com
+
+write_files:
+  - path: /home/developer/.ssh/config
+    content: |
+      Host *
+          ServerAliveInterval 60
+          ServerAliveCountMax 3
+    owner: developer:developer
+    permissions: '0600'
+  - path: /etc/ssh/sshd_config.d/99-custom.conf
+    content: |
+      PermitRootLogin no
+      PasswordAuthentication no
+      PubkeyAuthentication yes
+      Port 2222
+    permissions: '0644'
+
+runcmd:
+  - systemctl restart sshd
+  - ufw allow 2222/tcp
+  - ufw allow 60000:61000/udp  # Mosh port range
+  - ufw --force enable
+  - curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+  - echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+  - apt update
+  - apt install -y gh
+  - chown -R developer:developer /home/developer/.ssh
+```
+
+### Using Cloud-Init
+
+**Digital Ocean:**
+```bash
+# Create droplet with cloud-init
+doctl compute droplet create my-dev-server \
+  --image ubuntu-22-04-x64 \
+  --size s-1vcpu-1gb \
+  --region nyc3 \
+  --user-data-file cloud-config.yaml
+```
+
+**AWS EC2:**
+```bash
+# Launch instance with cloud-init
+aws ec2 run-instances \
+  --image-id ami-0c7217cdde317cfec \
+  --instance-type t2.micro \
+  --user-data file://cloud-config.yaml \
+  --security-group-ids sg-12345678
+```
+
+**Manual Upload:**
+Most VPS providers allow uploading cloud-init files during instance creation through their web interfaces.
+
+### Benefits of Cloud-Init
+
+- **Consistent Setup**: Same configuration every time
+- **Zero Manual Steps**: Server ready immediately after boot
+- **Version Control**: Track infrastructure changes in git
+- **Reproducible**: Easily recreate identical environments
+- **Security**: Automated security hardening from day one
+
+### Customization
+
+Before using, update the cloud-config.yaml:
+1. Replace the SSH key with your actual public key
+2. Modify the `developer` username if desired
+3. Add any additional packages or configuration needed
+4. Adjust firewall rules for your specific requirements
+
+The server will be fully configured and ready for development work within minutes of creation.


### PR DESCRIPTION
## Summary

- Added comprehensive cloud-init configuration for automated VPS setup
- Included practical usage examples for Digital Ocean and AWS EC2 
- Documented benefits and customization guidelines

## Changes

- **Cloud-Init Configuration**: Complete YAML example with user creation, package installation, SSH hardening, and GitHub CLI setup
- **Usage Examples**: Command-line examples for major cloud providers
- **Benefits Section**: Clear explanation of automation advantages
- **Customization Guide**: Step-by-step instructions for adapting the configuration

This enhancement allows users to completely automate their development server setup, eliminating manual configuration steps and ensuring consistent, secure environments.

🤖 Generated with [Claude Code](https://claude.ai/code)