### PR TITLE
Pin GitHub Actions to specific SHA commits for security

### DIFF
--- a/.github/workflows/deploy-readme.yml
+++ b/.github/workflows/deploy-readme.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Setup UV
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
         with:
           version: "latest"
 
@@ -33,10 +33,10 @@ jobs:
         run: uv run mkdocs build
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d # v4
           
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: ./site
 
@@ -49,4 +49,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,3 +94,7 @@ just issues
 - The site is configured to deploy to GitHub Pages
 - The `gh-issue.sh` script integrates with Claude Code for issue-driven development
 - Documentation is served on `0.0.0.0:8000` to allow access from remote connections (important for VPS development)
+
+## Workflow Guidance
+
+- Always run the justfile target after creating or changing gha workflows

--- a/justfile
+++ b/justfile
@@ -35,3 +35,7 @@ issue:
 # List all open GitHub issues
 issues:
     gh issue list --state open
+
+# Pin GitHub Actions to specific versions
+pin-actions:
+    pin-github-action .github/workflows/


### PR DESCRIPTION
## Summary
• Pin all GitHub Actions to specific commit SHAs instead of version tags
• Prevents supply chain attacks by ensuring immutable action versions
• Maintains reproducible builds and enhanced security posture

## Test plan
- [ ] Verify workflow still runs successfully on GitHub Actions
- [ ] Confirm all actions execute with expected functionality
- [ ] Validate deployment process remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)